### PR TITLE
Update methods to use async/await

### DIFF
--- a/src/UnitTestGenerator/Commands/GenerateUnitTestCommand.cs
+++ b/src/UnitTestGenerator/Commands/GenerateUnitTestCommand.cs
@@ -56,9 +56,9 @@ namespace UnitTestGenerator.Commands
             }
         }
 
-        protected override void Run()
+        protected override async void Run()
         {
-            var config = _configurationService.GetConfiguration();
+            var config = await _configurationService.GetConfiguration();
             if (string.IsNullOrWhiteSpace(config.UnitTestProjectName))
             {
                 var dialog = new ConfigureUnitTestProjectDialog();
@@ -69,8 +69,8 @@ namespace UnitTestGenerator.Commands
             var currentMethod = _testGeneratorService.GetActiveMethodDeclarationSyntax();
             if (currentMethod == null)
                 return;
-            var generatedTestModel = _testGeneratorService.CreateGeneratedTestModel(currentMethod);
-            var document = _testGeneratorService.OpenDocument(generatedTestModel);
+            var generatedTestModel = await _testGeneratorService.CreateGeneratedTestModel(currentMethod);
+            var document = await _testGeneratorService.OpenDocument(generatedTestModel);
 
 
 

--- a/src/UnitTestGenerator/Dialogs/AddUnitTestDialog.cs
+++ b/src/UnitTestGenerator/Dialogs/AddUnitTestDialog.cs
@@ -59,9 +59,9 @@ namespace UnitTestGenerator.Dialogs
             base.OnShown();
         }
 
-        void Confirm_Clicked(object sender, EventArgs e)
+        async void Confirm_Clicked(object sender, EventArgs e)
         { 
-            _testGeneratorService.GenerateUnitTest(_unitTestName.Text, _currentMethod, _document);
+            await _testGeneratorService.GenerateUnitTest(_unitTestName.Text, _currentMethod, _document);
             Hide();
         }
 

--- a/src/UnitTestGenerator/Dialogs/ConfigureUnitTestProjectDialog.cs
+++ b/src/UnitTestGenerator/Dialogs/ConfigureUnitTestProjectDialog.cs
@@ -92,11 +92,11 @@ namespace UnitTestGenerator.Dialogs
             }
         }
 
-        void Confirm_Clicked(object sender, EventArgs e)
+        async void Confirm_Clicked(object sender, EventArgs e)
         {
             if (!string.IsNullOrWhiteSpace(_selectedProject))
             {
-                var config = _configurationService.GetConfiguration();
+                var config = await _configurationService.GetConfiguration();
                 config.UnitTestProjectName = _selectedProject;
                 _configurationService.Save(config);
             }

--- a/src/UnitTestGenerator/Services/Implementations/ConfigurationService.cs
+++ b/src/UnitTestGenerator/Services/Implementations/ConfigurationService.cs
@@ -2,6 +2,7 @@
 using System.Composition;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using MonoDevelop.Ide;
 using MonoDevelop.Projects;
 using Newtonsoft.Json;
@@ -13,7 +14,7 @@ namespace UnitTestGenerator.Services.Implementations
     [Export(typeof(IConfigurationService))]
     public class ConfigurationService : IConfigurationService
     {
-        public Configuration GetConfiguration()
+        public async Task<Configuration> GetConfiguration()
         {
             var solution = IdeApp.Workspace.GetAllSolutions().FirstOrDefault();
 
@@ -38,7 +39,7 @@ namespace UnitTestGenerator.Services.Implementations
                 solutionItemsFolder.Files.Add(filePath);
                 using (var monitor = IdeApp.Workbench.ProgressMonitors.GetSaveProgressMonitor(false))
                 {
-                    solution.SaveAsync(monitor).ConfigureAwait(false);
+                    await solution.SaveAsync(monitor);
                 }
             }
             else

--- a/src/UnitTestGenerator/Services/Implementations/FileService.cs
+++ b/src/UnitTestGenerator/Services/Implementations/FileService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using MonoDevelop.Ide.Composition;
 using UnitTestGenerator.Services.Interfaces;
+using System.Threading.Tasks;
 
 namespace UnitTestGenerator.Services.Implementations
 {
@@ -16,9 +17,9 @@ namespace UnitTestGenerator.Services.Implementations
             _configurationService = CompositionManager.GetExportedValue<IConfigurationService>();
         }
 
-        public void GenerateFile(string namespaceId, string classId, string filePath)
+        public async Task GenerateFile(string namespaceId, string classId, string filePath)
         {
-            var config = _configurationService.GetConfiguration();
+            var config = await _configurationService.GetConfiguration();
             var lines = new List<string> { "using System;",
                 "using Moq;",
                 "using NUnit.Framework;",

--- a/src/UnitTestGenerator/Services/Interfaces/IConfigurationService.cs
+++ b/src/UnitTestGenerator/Services/Interfaces/IConfigurationService.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 using UnitTestGenerator.Models;
 
 namespace UnitTestGenerator.Services.Interfaces
 {
     public interface IConfigurationService
     {
-        Configuration GetConfiguration();
+        Task<Configuration> GetConfiguration();
         void Save(Configuration configuration);
     }
 }

--- a/src/UnitTestGenerator/Services/Interfaces/IFileService.cs
+++ b/src/UnitTestGenerator/Services/Interfaces/IFileService.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Threading.Tasks;
 namespace UnitTestGenerator.Services.Interfaces
 {
     public interface IFileService
     {
-        void GenerateFile(string namespaceId, string classId, string filePath);
+        Task GenerateFile(string namespaceId, string classId, string filePath);
     }
 }

--- a/src/UnitTestGenerator/Services/Interfaces/ITestGeneratorService.cs
+++ b/src/UnitTestGenerator/Services/Interfaces/ITestGeneratorService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using UnitTestGenerator.Models;
@@ -7,10 +7,10 @@ namespace UnitTestGenerator.Services.Interfaces
 {
     public interface ITestGeneratorService
     {
-        GeneratedTest CreateGeneratedTestModel(MethodDeclarationSyntax method);
+        Task<GeneratedTest> CreateGeneratedTestModel(MethodDeclarationSyntax method);
         MethodDeclarationSyntax GetActiveMethodDeclarationSyntax();
-        MonoDevelop.Ide.Gui.Document OpenDocument(GeneratedTest generatedTestModel);
-        void GenerateUnitTest(string unitTestName, MethodDeclarationSyntax currentMethod, MonoDevelop.Ide.Gui.Document document);
+        Task<MonoDevelop.Ide.Gui.Document> OpenDocument(GeneratedTest generatedTestModel);
+        Task GenerateUnitTest(string unitTestName, MethodDeclarationSyntax currentMethod, MonoDevelop.Ide.Gui.Document document);
         MethodDeclarationSyntax GenerateUnitTestMethodDeclaration(string returnTypeName, SyntaxTokenList modifiers, string methodName);
         UsingDirectiveSyntax GenerateTaskUsingSyntax();
     }


### PR DESCRIPTION
update helpers to return Task<T> instead of void
update calling references to await the tasks

Fixes #6 